### PR TITLE
Add JP region support for metric ingestion endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The following table lists available environment variables that can be set for th
 
 | Input | Type | Required | Description
 | ----- | ---- |----------| -----------
-| NR_METRIC_ENDPOINT | string | TRUE     | The metric api endpoint to forward metrics to (EU or US). Default: `US`
+| NR_METRIC_ENDPOINT | string | TRUE     | The metric api endpoint to forward metrics to (US, EU, or JP). Default: `US`
 | FORWARD_TO_NR | string | TRUE     | Toggle forwarding to New Relic - Can be one of: `True,False`. Default: `True`
 | LOGGING_ENABLED | string | FALSE    | The logging level for function logs emitted - Can be one of: `INFO,WARNING,ERROR,DEBUG`. Default: `INFO`
 | TENANCY_OCID | string | TRUE     | The OCID of the tenancy to which the metrics are being forwarded.

--- a/newrelic-metrics-function/function.py
+++ b/newrelic-metrics-function/function.py
@@ -31,6 +31,8 @@ if nr_metric_endpoint_enum == 'US'or nr_metric_endpoint_enum == 'newrelic-metric
     nr_metric_endpoint = 'https://metric-api.newrelic.com/oci/metric'
 elif nr_metric_endpoint_enum == 'EU'or nr_metric_endpoint_enum == 'newrelic-eu-metric-api':
     nr_metric_endpoint = 'https://metric-api.eu.newrelic.com/oci/metric'
+elif nr_metric_endpoint_enum == 'JP'or nr_metric_endpoint_enum == 'newrelic-jp-metric-api':
+    nr_metric_endpoint = 'https://metric-api.jp.newrelic.com/oci/metric'
 else:
     nr_metric_endpoint = nr_metric_endpoint_enum
     logger.warning(f"Unknown NR_METRIC_ENDPOINT: {nr_metric_endpoint_enum}, Please ensure valid value is set")

--- a/newrelic-metrics-setup/locals.tf
+++ b/newrelic-metrics-setup/locals.tf
@@ -29,6 +29,7 @@ locals {
   newrelic_graphql_endpoint = {
     US = "https://api.newrelic.com/graphql"
     EU = "https://api.eu.newrelic.com/graphql"
+    JP = "https://api.jp.newrelic.com/graphql"
   }[var.newrelic_endpoint]
   updateLinkAccount_graphql_query = <<EOF
 mutation {

--- a/newrelic-metrics-setup/schema.yml
+++ b/newrelic-metrics-setup/schema.yml
@@ -50,13 +50,14 @@ variables:
   newrelic_endpoint:
     type: enum
     title: New Relic Endpoint
-    description: The endpoint to hit for sending the metrics. Varies by region [US|EU]
+    description: The endpoint to hit for sending the metrics. Varies by region [US|EU|JP]
     required: true
     allowMultiple: false
     default: US
     enum:
       - US
       - EU
+      - JP
 
   newrelic_account_id:
     type: string

--- a/newrelic-metrics-setup/variables.tf
+++ b/newrelic-metrics-setup/variables.tf
@@ -21,10 +21,10 @@ variable "region" {
 variable "newrelic_endpoint" {
   type        = string
   default     = "US"
-  description = "The endpoint to hit for sending the metrics. Varies by region [US|EU]"
+  description = "The endpoint to hit for sending the metrics. Varies by region [US|EU|JP]"
   validation {
-    condition     = contains(["US", "EU"], var.newrelic_endpoint)
-    error_message = "Valid values for var: newrelic_endpoint are (US, EU)."
+    condition     = contains(["US", "EU", "JP"], var.newrelic_endpoint)
+    error_message = "Valid values for var: newrelic_endpoint are (US, EU, JP)."
   }
 }
 

--- a/newrelic-policy-setup/locals.tf
+++ b/newrelic-policy-setup/locals.tf
@@ -50,6 +50,7 @@ EOF
   newrelic_graphql_endpoint = {
     US = "https://api.newrelic.com/graphql"
     EU = "https://api.eu.newrelic.com/graphql"
+    JP = "https://api.jp.newrelic.com/graphql"
   }[var.newrelic_endpoint]
   linkAccount_graphql_query = <<EOF
 mutation {

--- a/newrelic-policy-setup/schema.yaml
+++ b/newrelic-policy-setup/schema.yaml
@@ -72,13 +72,14 @@ variables:
   newrelic_endpoint:
     type: enum
     title: New Relic Endpoint
-    description: The endpoint to hit for sending the metrics. Varies by region [US|EU]
+    description: The endpoint to hit for sending the metrics. Varies by region [US|EU|JP]
     required: true
     allowMultiple: false
     default: US
     enum:
       - US
       - EU
+      - JP
 
   newrelic_ingest_api_key:
     type: password

--- a/newrelic-policy-setup/variables.tf
+++ b/newrelic-policy-setup/variables.tf
@@ -21,10 +21,10 @@ variable "region" {
 variable "newrelic_endpoint" {
   type        = string
   default     = "US"
-  description = "The endpoint to hit for sending the metrics. Varies by region [US|EU]"
+  description = "The endpoint to hit for sending the metrics. Varies by region [US|EU|JP]"
   validation {
-    condition     = contains(["US", "EU"], var.newrelic_endpoint)
-    error_message = "Valid values for var: newrelic_endpoint are (US, EU)."
+    condition     = contains(["US", "EU", "JP"], var.newrelic_endpoint)
+    error_message = "Valid values for var: newrelic_endpoint are (US, EU, JP)."
   }
 }
 


### PR DESCRIPTION
Extend newrelic_endpoint to accept JP alongside US/EU across the function runtime, metrics-setup, and policy-setup terraform modules. Resolves to https://metric-api.jp.newrelic.com/oci/metric for metric forwarding and https://api.jp.newrelic.com/graphql for account linking.

# Description

  ## Summary
  - Add `JP` as a third valid value for `newrelic_endpoint` / `NR_METRIC_ENDPOINT` alongside `US` / `EU`
  - Function routes to `https://metric-api.jp.newrelic.com/oci/metric` for metric forwarding
  - Terraform modules (metrics-setup + policy-setup) route to `https://api.jp.newrelic.com/graphql` for account linking
  - Backward-compatible: validation widens, no existing US/EU tfvars or env values are rejected; default remains `US`

  ## Files changed
  - `newrelic-metrics-function/function.py` — JP branch in endpoint resolver
  - `newrelic-metrics-setup/{variables.tf,locals.tf,schema.yml}` — JP added to validation, graphql endpoint map, and ORM enum
  - `newrelic-policy-setup/{variables.tf,locals.tf,schema.yaml}` — same shape, kept consistent across both setup modules
  - `README.md` — `NR_METRIC_ENDPOINT` description updated

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Terraform standards](https://developer.hashicorp.com/terraform/cli/commands/fmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this change?


