### PR TITLE
NR-573977 - Update JP metric endpoint to nr-data.net domain

### DIFF
--- a/newrelic-metrics-function/function.py
+++ b/newrelic-metrics-function/function.py
@@ -32,7 +32,7 @@ if nr_metric_endpoint_enum == 'US'or nr_metric_endpoint_enum == 'newrelic-metric
 elif nr_metric_endpoint_enum == 'EU'or nr_metric_endpoint_enum == 'newrelic-eu-metric-api':
     nr_metric_endpoint = 'https://metric-api.eu.newrelic.com/oci/metric'
 elif nr_metric_endpoint_enum == 'JP'or nr_metric_endpoint_enum == 'newrelic-jp-metric-api':
-    nr_metric_endpoint = 'https://metric-api.jp.newrelic.com/oci/metric'
+    nr_metric_endpoint = 'https://metric-api.jp.nr-data.net/oci/metric'
 else:
     nr_metric_endpoint = nr_metric_endpoint_enum
     logger.warning(f"Unknown NR_METRIC_ENDPOINT: {nr_metric_endpoint_enum}, Please ensure valid value is set")


### PR DESCRIPTION
# Description

PBody:
## Summary
- Update the JP region metric endpoint from `metric-api.jp.newrelic.com` to `metric-api.jp.nr-data.net` in `newrelic-metrics-function/function.py`
- `nr-data.net` is the correct domain for telemetry ingestion in the JP region
- Only the metric ingestion host is changed; the NerdGraph host (`api.jp.newrelic.com/graphql`) in `locals.tf` files is intentionally left as-is — different service

## Test plan
- [x] Deploy with `NR_METRIC_ENDPOINT=JP` and verify metrics ingest into a JP-region NR account
- [x] Confirm no regression for `US` and `EU` paths

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [ ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Terraform standards](https://developer.hashicorp.com/terraform/cli/commands/fmt)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

