### PR TITLE
fix(security): stop clear-text logging of NR license key [NR-560509]

### DIFF
--- a/newrelic-metrics-function/function.py
+++ b/newrelic-metrics-function/function.py
@@ -68,8 +68,8 @@ def fetch_api_key_from_vault(secret_ocid, vault_region) -> str:
         try:
             if detailed_logging_enabled:
                 logger.debug(
-                    f"Secret Vault Access time stamp: {datetime.datetime.now().isoformat(timespec='microseconds')} - "
-                    f"secret_ocid: {secret_ocid} in region: {vault_region}")
+                    f"Secret Vault access at {datetime.datetime.now().isoformat(timespec='microseconds')} "
+                    f"in region: {vault_region}")
 
             signer = oci.auth.signers.get_resource_principals_signer()
             secrets_client = oci.secrets.SecretsClient(config={}, signer=signer)
@@ -166,13 +166,15 @@ def _send_metrics_msg_to_newrelic(metrics_message) :
         return ""
 
     if detailed_logging_enabled:
-        logger.debug(f"Sending metrics to New Relic endpoint: {nr_metric_endpoint} with headers: {api_headers} with gzip payload: {compressed_payload}")
+        logger.debug(
+            f"Sending metrics to New Relic endpoint: {nr_metric_endpoint} "
+            f"(payload size: {len(compressed_payload)} bytes, license key configured: {nr_ingest_key is not None})")
 
     http_response = _session.post(nr_metric_endpoint, data=compressed_payload, headers=api_headers)
     http_response.raise_for_status()
 
     if detailed_logging_enabled:
-        logger.debug(f"Sent payload size={len(compressed_payload)} encoding={api_headers.get('content-encoding', None)}")
+        logger.debug(f"Sent payload size={len(compressed_payload)} bytes encoding=gzip")
     return http_response.text
 
 


### PR DESCRIPTION
Resolves CodeQL `py/clear-text-logging-sensitive-data` alerts #6, #7, #8 in `newrelic-metrics-function/function.py`.

- Drop `secret_ocid` from the vault-access debug log (alert #6).
- Stop logging `api_headers` (which holds the `X-License-Key`) and the raw gzip payload; log a taint-safe `license key configured` boolean instead (alert #7).
- Drop the `api_headers.get('content-encoding')` reference, which was always `None` (alert #8).

No behavior change beyond log content; the POST, headers, and key handling are untouched.

Jira: NR-560509