### PR TITLE
NR-582479: expose trust_type (UPST/RPST) in policy-setup ORM stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ This repository contains integrations to forward metrics from Oracle Cloud Infra
 * [New Relic Ingest Key & API Key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#license-key)
 * OCI user with Cloud Administrator role to create resources/stacks
 
+## Trust type: UPST or RPST
+
+New Relic supports two WIF trust types for OCI. Pick one before deploying the ORM stack.
+
+| Trust type | When to use | Setup docs |
+|------------|-------------|------------|
+| **UPST** (default) | Most customers. WIF impersonates a dedicated service user. Simplest path. | [UPST setup](https://docs-preview.newrelic.com/docs/oracle-cloud-infrastructure#upst-setup) |
+| **RPST** | Multi-account customers, customers hitting OCI's IAM policy-statement limit, or anyone who wants claim-based / tag-based authorization. | [RPST setup](https://docs-preview.newrelic.com/docs/oracle-cloud-infrastructure#rpst-setup) |
+
+The `trust_type` variable in the Policy Stack (below) defaults to `UPST`. Set it to `RPST` inside the OCI Resource Manager form if your identity-propagation trust was created with `subjectType: Resource`. If you also want tag-based scoping via `ext_resource_tag`, use the [terraform provider](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/cloud_oci_link_account) — the ORM stack does not currently expose `resource_tag`.
+
 ## Installation
 
 For convenience, Terraform configurations are supplied to create OCI Resource Manager (ORM) stacks. Each sub-section below outlines pre-requisites, steps, and resulting resources created for either metrics or logs ingestion.

--- a/newrelic-policy-setup/locals.tf
+++ b/newrelic-policy-setup/locals.tf
@@ -21,7 +21,7 @@ locals {
   user_api_key = var.create_vault ? var.newrelic_user_api_key : (
     var.user_key_secret_ocid != "" ? base64decode(data.oci_secrets_secretbundle.user_api_key[0].secret_bundle_content[0].content) : var.newrelic_user_api_key
   )
-  updateLinkAccount_graphql_query  = <<EOF
+  updateLinkAccount_graphql_query = <<EOF
 mutation {
   cloudUpdateAccount(
     accountId: ${var.newrelic_account_id}
@@ -68,6 +68,7 @@ mutation {
         ociClientSecret: "${var.client_secret}"
         ociDomainUrl: "${var.oci_domain_url}"
         instrumentationType: "${local.instrumentation_type}"
+        trustType: "${var.trust_type}"
       }
     }
   ) {

--- a/newrelic-policy-setup/locals.tf
+++ b/newrelic-policy-setup/locals.tf
@@ -21,7 +21,7 @@ locals {
   user_api_key = var.create_vault ? var.newrelic_user_api_key : (
     var.user_key_secret_ocid != "" ? base64decode(data.oci_secrets_secretbundle.user_api_key[0].secret_bundle_content[0].content) : var.newrelic_user_api_key
   )
-  updateLinkAccount_graphql_query = <<EOF
+  updateLinkAccount_graphql_query  = <<EOF
 mutation {
   cloudUpdateAccount(
     accountId: ${var.newrelic_account_id}

--- a/newrelic-policy-setup/schema.yaml
+++ b/newrelic-policy-setup/schema.yaml
@@ -35,6 +35,7 @@ groupings:
             - ${policy_stack}
             - "METRICS,LOGS,COMMON"
     variables:
+      - ${trust_type}
       - ${client_id}
       - ${client_secret}
       - ${oci_domain_url}
@@ -155,6 +156,18 @@ variables:
     description: A string indicating which parts of the stack to deploy. Use comma-separated values from METRICS, LOGS, COMMON.
     visible: true
     required: true
+
+  trust_type:
+    type: enum
+    title: OCI WIF Trust Type
+    description: OCI WIF trust type. UPST (default, service-user impersonation) or RPST (claim-based ephemeral principal). Must match how your OCI identity propagation trust was created.
+    required: true
+    allowMultiple: false
+    default: UPST
+    enum:
+      - UPST
+      - RPST
+    visible: true
 
   client_id:
     type: string

--- a/newrelic-policy-setup/variables.tf
+++ b/newrelic-policy-setup/variables.tf
@@ -38,7 +38,7 @@ variable "newrelic_ingest_api_key" {
 variable "newrelic_user_api_key" {
   type        = string
   sensitive   = true
-  default = ""
+  default     = ""
   description = "The User API key for Linking the OCI Account to the New Relic account"
 }
 
@@ -97,8 +97,18 @@ variable "user_key_secret_ocid" {
 }
 
 variable "ingest_key_secret_ocid" {
-    type        = string
-    default     = ""
-    description = "The OCID of the secret containing the New Relic Ingest License API key"
+  type        = string
+  default     = ""
+  description = "The OCID of the secret containing the New Relic Ingest License API key"
+}
+
+variable "trust_type" {
+  type        = string
+  default     = "UPST"
+  description = "OCI WIF trust type. UPST (default, service-user impersonation) or RPST (claim-based ephemeral principal). Must match how your OCI identity propagation trust was created."
+  validation {
+    condition     = contains(["UPST", "RPST"], var.trust_type)
+    error_message = "trust_type must be either 'UPST' or 'RPST'."
+  }
 }
 

--- a/newrelic-policy-setup/variables.tf
+++ b/newrelic-policy-setup/variables.tf
@@ -38,7 +38,7 @@ variable "newrelic_ingest_api_key" {
 variable "newrelic_user_api_key" {
   type        = string
   sensitive   = true
-  default     = ""
+  default = ""
   description = "The User API key for Linking the OCI Account to the New Relic account"
 }
 
@@ -97,9 +97,9 @@ variable "user_key_secret_ocid" {
 }
 
 variable "ingest_key_secret_ocid" {
-  type        = string
-  default     = ""
-  description = "The OCID of the secret containing the New Relic Ingest License API key"
+    type        = string
+    default     = ""
+    description = "The OCID of the secret containing the New Relic Ingest License API key"
 }
 
 variable "trust_type" {


### PR DESCRIPTION
## Summary
- New `trust_type` enum variable in `newrelic-policy-setup/schema.yaml` + `variables.tf`. Default UPST.
- `trust_type` propagated into the `cloudLinkAccount` NerdGraph mutation body inside `locals.tf` (this stack uses a `null_resource` + `local-exec curl`, not the native `newrelic_cloud_oci_link_account` terraform resource).
- README section documenting UPST vs RPST.

Depends on: terraform-provider-newrelic PR [#3101](https://github.com/newrelic/terraform-provider-newrelic/pull/3101) (already merged 2026-06-09) — the backend understands `trust_type` / `resource_tag`.

Pairs with:
- `beta-docs-site` PR [#705](https://github.com/newrelic/beta-docs-site/pull/705) — adds `#upst-setup` / `#rpst-setup` anchors.
- `shared-component-framework-configs` PR [#1286](https://source.datanerd.us/nr1-dev-experience/shared-component-framework-configs/pull/1286) — wizard passes `trust_type` in the ORM launch URL.

Tracks: NR-582479 (parent: NR-565739).





## Test plan
- [x] `terraform validate` clean with UPST default.
- [x] `terraform validate` clean with `TF_VAR_trust_type=RPST`.
- [x] `terraform plan` fails on `TF_VAR_trust_type=BOGUS` with the exact validation error `trust_type must be either 'UPST' or 'RPST'`.
- [x] Manual: deploy stack via OCI Resource Manager preview UI for both trust types; confirm `svc_user_name` behaviour on RPST is acceptable (dangling ORM reference is pre-existing tech debt from a prior commit).
- [x] Manual: end-to-end from the wizard → RPST → Deploy to OCI → linked account has `provider_accounts.params.oci.trust_type = "RPST"` in staging.