### PR TITLE
fix(oci): pass trustType as bare GraphQL enum, not a quoted string

### DIFF
--- a/newrelic-policy-setup/locals.tf
+++ b/newrelic-policy-setup/locals.tf
@@ -68,7 +68,7 @@ mutation {
         ociClientSecret: "${var.client_secret}"
         ociDomainUrl: "${var.oci_domain_url}"
         instrumentationType: "${local.instrumentation_type}"
-        trustType: "${var.trust_type}"
+        trustType: ${var.trust_type}
       }
     }
   ) {


### PR DESCRIPTION
## Summary

- `trustType` is a `CloudOciTrustType` **enum** in NerdGraph, not a `String`
- The Terraform heredoc had `trustType: "${var.trust_type}"` — the surrounding `"..."` caused Terraform to render the mutation as `trustType: "UPST"` (a string literal)
- NerdGraph rejected it with: `In field "trustType": Expected type "CloudOciTrustType", found "UPST"`
- Fix: remove the quotes so it renders as the bare enum value `trustType: UPST`

## Change

```diff
-        trustType: "${var.trust_type}"
+        trustType: ${var.trust_type}
```

This follows the same pattern already used in the same heredoc for integer/non-string fields (e.g. `accountId: ${var.newrelic_account_id}`).

## Test plan

- [x] Run `terraform plan` and confirm the rendered mutation contains `trustType: UPST` (no quotes)
- [x] Run `terraform apply` and confirm the `cloudLinkAccount` mutation succeeds without a type error

🤖 Generated with [Claude Code](https://claude.com/claude-code)