### PR TITLE
feat: add oci  cci cloud cost support to ORM 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,0 @@
-.idea/
-*.tfstate
-*.tfstate.backup
-.terraform/
-.terraform.lock.hcl

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea/
+*.tfstate
+*.tfstate.backup
+.terraform/
+.terraform.lock.hcl

--- a/newrelic-policy-setup/locals.tf
+++ b/newrelic-policy-setup/locals.tf
@@ -11,16 +11,33 @@ locals {
   newRelic_Metrics_Access_Policy   = contains(split(",", var.policy_stack), "METRICS")
   newRelic_Logs_Access_Policy      = contains(split(",", var.policy_stack), "LOGS")
   newRelic_Core_Integration_Policy = contains(split(",", var.policy_stack), "COMMON")
+  newRelic_Cost_Access_Policy      = contains(split(",", var.policy_stack), "COST")
   newrelic_logs_policy             = "newrelic_logs_policy_ORM_DO_NOT_REMOVE_${local.random_id}"
   newrelic_metrics_policy          = "newrelic_metrics_policy_ORM_DO_NOT_REMOVE_${local.random_id}"
   newrelic_common_policy           = "newrelic_common_policy_ORM_DO_NOT_REMOVE_${local.random_id}"
+  newrelic_cost_policy             = "newrelic_cost_policy_ORM_DO_NOT_REMOVE_${local.random_id}"
   dynamic_group_name               = "newrelic_dynamic_group_ORM_DO_NOT_REMOVE_${local.random_id}"
-  instrumentation_type             = local.newRelic_Metrics_Access_Policy && local.newRelic_Logs_Access_Policy && local.newRelic_Core_Integration_Policy ? "METRICS,LOGS" : (local.newRelic_Logs_Access_Policy && local.newRelic_Core_Integration_Policy) || local.newRelic_Logs_Access_Policy ? "LOGS" : (local.newRelic_Metrics_Access_Policy && local.newRelic_Core_Integration_Policy) || local.newRelic_Metrics_Access_Policy ? "METRICS" : ""
+  instrumentation_type             = join(",", compact([
+    local.newRelic_Metrics_Access_Policy ? "METRICS" : "",
+    local.newRelic_Logs_Access_Policy    ? "LOGS"    : "",
+    local.newRelic_Cost_Access_Policy    ? "COST"    : "",
+  ]))
   linked_account_id                = var.linked_account_id != null ? var.linked_account_id : ""
   random_id                        = substr(md5(timestamp()), 0, 4)
   user_api_key = var.create_vault ? var.newrelic_user_api_key : (
     var.user_key_secret_ocid != "" ? base64decode(data.oci_secrets_secretbundle.user_api_key[0].secret_bundle_content[0].content) : var.newrelic_user_api_key
   )
+  # Vault/compartment OCIDs for the update mutation — only populated when COMMON is present.
+  # The guard for [0].id MUST match the resource's count condition exactly, otherwise
+  # Terraform evaluates the reference at plan time when count=0 and fails.
+  # - vault secrets:  count = newRelic_Core_Integration_Policy && create_vault ? 1 : 0
+  # - compartment:    count = newRelic_Core_Integration_Policy ? 1 : 0
+  # When COMMON absent → empty string; beyond-api-v2 getValueOrDefault falls back to
+  # existing auth_label values — no overwrite.
+  update_ingest_vault_ocid  = local.newRelic_Core_Integration_Policy && var.create_vault ? oci_vault_secret.ingest_api_key[0].id : (local.newRelic_Core_Integration_Policy ? var.ingest_key_secret_ocid : "")
+  update_user_vault_ocid    = local.newRelic_Core_Integration_Policy && var.create_vault ? oci_vault_secret.user_api_key[0].id : (local.newRelic_Core_Integration_Policy ? var.user_key_secret_ocid : "")
+  update_compartment_ocid   = local.newRelic_Core_Integration_Policy ? oci_identity_compartment.newrelic_compartment[0].id : ""
+
   updateLinkAccount_graphql_query  = <<EOF
 mutation {
   cloudUpdateAccount(
@@ -30,6 +47,9 @@ mutation {
         linkedAccountId: ${local.linked_account_id}
         ociRegion: "${var.region}"
         instrumentationType: "${local.instrumentation_type}"
+        ${local.newRelic_Core_Integration_Policy ? "ingestVaultOcid: \"${local.update_ingest_vault_ocid}\"" : ""}
+        ${local.newRelic_Core_Integration_Policy ? "userVaultOcid: \"${local.update_user_vault_ocid}\"" : ""}
+        ${local.newRelic_Core_Integration_Policy ? "compartmentOcid: \"${local.update_compartment_ocid}\"" : ""}
       }
   }
 ) {

--- a/newrelic-policy-setup/main.tf
+++ b/newrelic-policy-setup/main.tf
@@ -123,6 +123,25 @@ resource "oci_identity_policy" "nr_logs_policy" {
   freeform_tags = local.freeform_tags
 }
 
+# Cross-tenancy endorsement so WIF-authenticated principals (UPST service user or RPST
+# federated app) can read Oracle's shared FOCUS cost-report bucket in the reporting tenancy.
+# No principal-type condition — both UPST (request.principal.type=user) and RPST
+# (request.principal.type=identityfederateddomainapp) must be able to cross the boundary.
+# The ALLOW statement in the customer's tenancy (created during WIF setup) already gates
+# which specific principals can act; this ENDORSE just permits crossing the tenancy.
+resource "oci_identity_policy" "nr_cost_policy" {
+  count          = local.is_home_region && local.newRelic_Cost_Access_Policy ? 1 : 0
+  compartment_id = var.tenancy_ocid
+  description    = "[DO NOT REMOVE] Policy to endorse New Relic principals to read OCI FOCUS cost reports from the shared Oracle reporting tenancy"
+  name           = local.newrelic_cost_policy
+  statements = [
+    "DEFINE tenancy usage-report as ocid1.tenancy.oc1..aaaaaaaaned4fkpkisbwjlr56u7cj63lf3wffbilvqknstgtvzub7vhqkggq",
+    "endorse any-user to read objects in tenancy usage-report",
+  ]
+  defined_tags  = {}
+  freeform_tags = local.freeform_tags
+}
+
 #Resource for the metrics/Logging (Common) policies
 resource "oci_identity_policy" "nr_common_policy" {
   count          = local.is_home_region && local.newRelic_Core_Integration_Policy ? 1 : 0

--- a/newrelic-policy-setup/schema.yaml
+++ b/newrelic-policy-setup/schema.yaml
@@ -34,6 +34,18 @@ groupings:
         - eq:
             - ${policy_stack}
             - "METRICS,LOGS,COMMON"
+        - eq:
+            - ${policy_stack}
+            - "COST,COMMON"
+        - eq:
+            - ${policy_stack}
+            - "METRICS,COST,COMMON"
+        - eq:
+            - ${policy_stack}
+            - "LOGS,COST,COMMON"
+        - eq:
+            - ${policy_stack}
+            - "METRICS,LOGS,COST,COMMON"
     variables:
       - ${trust_type}
       - ${client_id}
@@ -101,6 +113,18 @@ variables:
             - eq:
                 - ${policy_stack}
                 - "METRICS,LOGS,COMMON"
+            - eq:
+                - ${policy_stack}
+                - "COST,COMMON"
+            - eq:
+                - ${policy_stack}
+                - "METRICS,COST,COMMON"
+            - eq:
+                - ${policy_stack}
+                - "LOGS,COST,COMMON"
+            - eq:
+                - ${policy_stack}
+                - "METRICS,LOGS,COST,COMMON"
 
   newrelic_user_api_key:
     type: password
@@ -131,6 +155,18 @@ variables:
         - eq:
             - ${policy_stack}
             - "LOGS"
+        - eq:
+            - ${policy_stack}
+            - "COST"
+        - eq:
+            - ${policy_stack}
+            - "METRICS,COST"
+        - eq:
+            - ${policy_stack}
+            - "LOGS,COST"
+        - eq:
+            - ${policy_stack}
+            - "METRICS,LOGS,COST"
 
 
   link_account_name:
@@ -149,11 +185,23 @@ variables:
         - eq:
             - ${policy_stack}
             - "METRICS,LOGS,COMMON"
+        - eq:
+            - ${policy_stack}
+            - "COST,COMMON"
+        - eq:
+            - ${policy_stack}
+            - "METRICS,COST,COMMON"
+        - eq:
+            - ${policy_stack}
+            - "LOGS,COST,COMMON"
+        - eq:
+            - ${policy_stack}
+            - "METRICS,LOGS,COST,COMMON"
 
   policy_stack:
     type: string
     title: New Relic Policy Instrumentation
-    description: A string indicating which parts of the stack to deploy. Use comma-separated values from METRICS, LOGS, COMMON.
+    description: A string indicating which parts of the stack to deploy. Use comma-separated values from METRICS, LOGS, COMMON, COST.
     visible: true
     required: true
 
@@ -230,5 +278,17 @@ variables:
             - eq:
                 - ${policy_stack}
                 - "METRICS,LOGS,COMMON"
+            - eq:
+                - ${policy_stack}
+                - "COST,COMMON"
+            - eq:
+                - ${policy_stack}
+                - "METRICS,COST,COMMON"
+            - eq:
+                - ${policy_stack}
+                - "LOGS,COST,COMMON"
+            - eq:
+                - ${policy_stack}
+                - "METRICS,LOGS,COST,COMMON"
 
 

--- a/newrelic-policy-setup/variables.tf
+++ b/newrelic-policy-setup/variables.tf
@@ -61,7 +61,7 @@ variable "linked_account_id" {
 
 variable "policy_stack" {
   type        = string
-  description = "A string indicating which parts of the stack to deploy. Use comma-separated values from METRICS, LOGS, COMMON."
+  description = "A string indicating which parts of the stack to deploy. Use comma-separated values from METRICS, LOGS, COMMON, COST."
 }
 
 variable "client_id" {


### PR DESCRIPTION
- Add COST to policy_stack: new nr_cost_policy resource with cross-tenancy endorsement for Oracle shared cost-report bucket
- Refactor instrumentation_type to use join/compact (cleaner, supports COST combos)
- Add update_ingest/user/compartment_ocid locals gated on COMMON flag
- Conditionally include vault/compartment fields in cloudUpdateAccount mutation
- Extend schema.yaml visibility conditions for all COST combinations
- Update policy_stack variable description to include COST

# Description

Please include a summary of the change and which issue is fixed (if relevant).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [ ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Terraform standards](https://developer.hashicorp.com/terraform/cli/commands/fmt)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Step 1
- Step 2
- etc
