### PR TITLE
NR-590157: fix trust_type RPST not populating in ORM UI

### DIFF
--- a/newrelic-policy-setup/schema.yaml
+++ b/newrelic-policy-setup/schema.yaml
@@ -163,7 +163,6 @@ variables:
     description: OCI WIF trust type. UPST (default, service-user impersonation) or RPST (claim-based ephemeral principal). Must match how your OCI identity propagation trust was created.
     required: true
     allowMultiple: false
-    default: UPST
     enum:
       - UPST
       - RPST


### PR DESCRIPTION
## Summary

- Removes `default: UPST` from the `trust_type` enum variable in `newrelic-policy-setup/schema.yaml`

## Root Cause

For `type: enum` fields, OCI ORM uses the schema `default` value on initial render, overriding any value supplied via `zipUrlVariables`. Because `trust_type` had `default: UPST`, passing `trust_type=RPST` in the stack URL was silently overridden — ORM always showed and used UPST.

Variables without a `default` (`newrelic_account_id`, `policy_stack`) were unaffected, which is why only `trust_type` exhibited this behaviour.

## Fix

Removing `default: UPST` means ORM no longer has a competing value to override the URL-supplied input. The user is now required to explicitly select UPST or RPST, which is safer than a silent default.

## Test plan

- [ ] Build a test ORM stack URL with `zipUrlVariables` containing `trust_type=RPST`
- [ ] Confirm the ORM form pre-selects RPST (not UPST)
- [ ] Confirm applying the stack passes `RPST` to the GraphQL `cloudLinkAccount` mutation

🤖 Generated with [Claude Code](https://claude.com/claude-code)